### PR TITLE
Update URL for Mathématiques Magiques

### DIFF
--- a/sites/Therese.py
+++ b/sites/Therese.py
@@ -5,7 +5,7 @@ import requests
 import bs4
 from zipfile import ZipFile
 
-regex = 'therese.eveilleau.pagesperso-orange.fr'
+regex = 'mathsmagiques.fr'
 ver = 6
 
 class Therese(fpclib.Curation):


### PR DESCRIPTION
Orange closed their personal web hosting service a few years back so the website migrated to another domain